### PR TITLE
[#40] Provide cleaner contracts

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Alexey Mayshev. All rights reserved.
+// Copyright (c) 2024 Alexey Mayshev. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,330 +15,131 @@
 package otter
 
 import (
-	"sync"
 	"time"
 
-	"github.com/maypok86/otter/internal/expire"
-	"github.com/maypok86/otter/internal/hashtable"
-	"github.com/maypok86/otter/internal/lossy"
-	"github.com/maypok86/otter/internal/node"
-	"github.com/maypok86/otter/internal/queue"
-	"github.com/maypok86/otter/internal/s3fifo"
+	"github.com/maypok86/otter/internal/core"
 	"github.com/maypok86/otter/internal/stats"
-	"github.com/maypok86/otter/internal/unixtime"
-	"github.com/maypok86/otter/internal/xmath"
-	"github.com/maypok86/otter/internal/xruntime"
 )
 
-func zeroValue[V any]() V {
-	var zero V
-	return zero
+// Stats is a thread-safe statistics collector.
+type Stats struct {
+	s *stats.Stats
 }
 
-// Config is a set of cache settings.
-type Config[K comparable, V any] struct {
-	Capacity     int
-	StatsEnabled bool
-	CostFunc     func(key K, value V) uint32
+func newStats(s *stats.Stats) Stats {
+	return Stats{s: s}
+}
+
+// Hits returns the number of cache hits.
+func (s Stats) Hits() int64 {
+	return s.s.Hits()
+}
+
+// Misses returns the number of cache misses.
+func (s Stats) Misses() int64 {
+	return s.s.Misses()
+}
+
+// Ratio returns the cache hit ratio.
+func (s Stats) Ratio() float64 {
+	return s.s.Ratio()
+}
+
+type baseCache[K comparable, V any] struct {
+	cache *core.Cache[K, V]
+}
+
+func newBaseCache[K comparable, V any](c core.Config[K, V]) baseCache[K, V] {
+	return baseCache[K, V]{
+		cache: core.NewCache(c),
+	}
+}
+
+// Has checks if there is an item with the given key in the cache.
+func (bs baseCache[K, V]) Has(key K) bool {
+	return bs.cache.Has(key)
+}
+
+// Get returns the value associated with the key in this cache.
+func (bs baseCache[K, V]) Get(key K) (V, bool) {
+	return bs.cache.Get(key)
+}
+
+// Delete removes the association for this key from the cache.
+func (bs baseCache[K, V]) Delete(key K) {
+	bs.cache.Delete(key)
+}
+
+// Range iterates over all items in the cache.
+//
+// Iteration stops early when the given function returns false.
+func (bs baseCache[K, V]) Range(f func(key K, value V) bool) {
+	bs.cache.Range(f)
+}
+
+// Clear clears the hash table, all policies, buffers, etc.
+//
+// NOTE: this operation must be performed when no requests are made to the cache otherwise the behavior is undefined.
+func (bs baseCache[K, V]) Clear() {
+	bs.cache.Clear()
+}
+
+// Close clears the hash table, all policies, buffers, etc and stop all goroutines.
+//
+// NOTE: this operation must be performed when no requests are made to the cache otherwise the behavior is undefined.
+func (bs baseCache[K, V]) Close() {
+	bs.cache.Close()
+}
+
+// Size returns the current number of items in the cache.
+func (bs baseCache[K, V]) Size() int {
+	return bs.cache.Size()
+}
+
+// Capacity returns the cache capacity.
+func (bs baseCache[K, V]) Capacity() int {
+	return bs.cache.Capacity()
+}
+
+// Stats returns a current snapshot of this cache's cumulative statistics.
+func (bs baseCache[K, V]) Stats() Stats {
+	return newStats(bs.cache.Stats())
 }
 
 // Cache is a structure performs a best-effort bounding of a hash table using eviction algorithm
 // to determine which entries to evict when the capacity is exceeded.
 type Cache[K comparable, V any] struct {
-	hashmap       *hashtable.Map[K, V]
-	policy        *s3fifo.Policy[K, V]
-	expirePolicy  *expire.Policy[K, V]
-	stats         *stats.Stats
-	readBuffers   []*lossy.Buffer[node.Node[K, V]]
-	writeBuffer   *queue.MPSC[node.WriteTask[K, V]]
-	evictionMutex sync.Mutex
-	closeOnce     sync.Once
-	isClosed      bool
-	doneClear     chan struct{}
-	costFunc      func(key K, value V) uint32
-	capacity      int
-	mask          uint32
+	baseCache[K, V]
 }
 
-// NewCache returns a new cache instance based on the settings from Config.
-//
-// You should always prefer to create a cache using Builder instead of this method.
-func NewCache[K comparable, V any](c Config[K, V]) *Cache[K, V] {
-	parallelism := xruntime.Parallelism()
-	roundedParallelism := int(xmath.RoundUpPowerOf2(parallelism))
-	writeBufferCapacity := 128 * roundedParallelism
-	readBuffersCount := 4 * roundedParallelism
-
-	readBuffers := make([]*lossy.Buffer[node.Node[K, V]], 0, readBuffersCount)
-	for i := 0; i < readBuffersCount; i++ {
-		readBuffers = append(readBuffers, lossy.New[node.Node[K, V]]())
-	}
-
-	cache := &Cache[K, V]{
-		hashmap:     hashtable.New[K, V](),
-		policy:      s3fifo.NewPolicy[K, V](uint32(c.Capacity)),
-		readBuffers: readBuffers,
-		writeBuffer: queue.NewMPSC[node.WriteTask[K, V]](writeBufferCapacity),
-		doneClear:   make(chan struct{}),
-		mask:        uint32(readBuffersCount - 1),
-		costFunc:    c.CostFunc,
-		capacity:    c.Capacity,
-	}
-
-	cache.expirePolicy = expire.NewPolicy[K, V]()
-	if c.StatsEnabled {
-		cache.stats = stats.New()
-	}
-
-	unixtime.Start()
-	go cache.process()
-	go cache.cleanup()
-
-	return cache
-}
-
-func (c *Cache[K, V]) getReadBufferIdx() int {
-	return int(xruntime.Fastrand() & c.mask)
-}
-
-// Has checks if there is an item with the given key in the cache.
-func (c *Cache[K, V]) Has(key K) bool {
-	_, ok := c.Get(key)
-	return ok
-}
-
-// Get returns the value associated with the key in this cache.
-func (c *Cache[K, V]) Get(key K) (V, bool) {
-	got, ok := c.hashmap.Get(key)
-	if !ok {
-		c.stats.IncMisses()
-		return zeroValue[V](), false
-	}
-
-	if got.IsExpired() {
-		c.writeBuffer.Insert(node.NewDeleteTask(got))
-		c.stats.IncMisses()
-		return zeroValue[V](), false
-	}
-
-	c.afterGet(got)
-	c.stats.IncHits()
-
-	return got.Value(), ok
-}
-
-func (c *Cache[K, V]) afterGet(got *node.Node[K, V]) {
-	idx := c.getReadBufferIdx()
-	pb := c.readBuffers[idx].Add(got)
-	if pb != nil {
-		c.evictionMutex.Lock()
-		c.policy.Read(pb.Returned)
-		c.evictionMutex.Unlock()
-
-		c.readBuffers[idx].Free()
+func newCache[K comparable, V any](c core.Config[K, V]) Cache[K, V] {
+	return Cache[K, V]{
+		baseCache: newBaseCache(c),
 	}
 }
 
 // Set associates the value with the key in this cache.
 //
 // If it returns false, then the key-value item had too much cost and the Set was dropped.
-func (c *Cache[K, V]) Set(key K, value V) bool {
-	return c.set(key, value, 0)
+func (c Cache[K, V]) Set(key K, value V) bool {
+	return c.cache.Set(key, value)
 }
 
-// SetWithTTL associates the value with the key in this cache and sets the custom ttl for this key-value item.
+// CacheWithVariableTTL is a structure performs a best-effort bounding of a hash table using eviction algorithm
+// to determine which entries to evict when the capacity is exceeded.
+type CacheWithVariableTTL[K comparable, V any] struct {
+	baseCache[K, V]
+}
+
+func newCacheWithVariableTTL[K comparable, V any](c core.Config[K, V]) CacheWithVariableTTL[K, V] {
+	return CacheWithVariableTTL[K, V]{
+		baseCache: newBaseCache(c),
+	}
+}
+
+// Set associates the value with the key in this cache and sets the custom ttl for this key-value item.
 //
-// If it returns false, then the key-value item had too much cost and the SetWithTTL was dropped.
-func (c *Cache[K, V]) SetWithTTL(key K, value V, ttl time.Duration) bool {
-	ttl = (ttl + time.Second - 1) / time.Second
-	expiration := unixtime.Now() + uint32(ttl)
-	return c.set(key, value, expiration)
-}
-
-func (c *Cache[K, V]) set(key K, value V, expiration uint32) bool {
-	cost := c.costFunc(key, value)
-	if cost > c.policy.MaxAvailableCost() {
-		return false
-	}
-
-	n := node.New(key, value, expiration, cost)
-	evicted := c.hashmap.Set(n)
-	if evicted != nil {
-		// update
-		c.writeBuffer.Insert(node.NewUpdateTask(n, evicted))
-	} else {
-		// insert
-		c.writeBuffer.Insert(node.NewAddTask(n))
-	}
-
-	return true
-}
-
-// Delete removes the association for this key from the cache.
-func (c *Cache[K, V]) Delete(key K) {
-	deleted := c.hashmap.Delete(key)
-	if deleted != nil {
-		c.writeBuffer.Insert(node.NewDeleteTask(deleted))
-	}
-}
-
-func (c *Cache[K, V]) cleanup() {
-	expired := make([]*node.Node[K, V], 0, 128)
-	for {
-		time.Sleep(time.Second)
-
-		c.evictionMutex.Lock()
-		if c.isClosed {
-			return
-		}
-
-		e := c.expirePolicy.RemoveExpired(expired)
-		c.policy.Delete(e)
-
-		c.evictionMutex.Unlock()
-
-		for _, n := range e {
-			c.hashmap.EvictNode(n)
-		}
-
-		expired = clearBuffer(expired)
-	}
-}
-
-func (c *Cache[K, V]) process() {
-	bufferCapacity := 64
-	buffer := make([]node.WriteTask[K, V], 0, bufferCapacity)
-	deleted := make([]*node.Node[K, V], 0, bufferCapacity)
-	i := 0
-	for {
-		task := c.writeBuffer.Remove()
-
-		if task.IsClear() || task.IsClose() {
-			buffer = clearBuffer(buffer)
-			c.writeBuffer.Clear()
-
-			c.evictionMutex.Lock()
-			c.policy.Clear()
-			c.expirePolicy.Clear()
-			if task.IsClose() {
-				c.isClosed = true
-			}
-			c.evictionMutex.Unlock()
-
-			c.doneClear <- struct{}{}
-			if task.IsClose() {
-				break
-			}
-			continue
-		}
-
-		buffer = append(buffer, task)
-		i++
-		if i >= bufferCapacity {
-			i -= bufferCapacity
-
-			c.evictionMutex.Lock()
-
-			for _, t := range buffer {
-				switch {
-				case t.IsDelete():
-					c.expirePolicy.Delete(t.Node())
-				case t.IsAdd():
-					c.expirePolicy.Add(t.Node())
-				case t.IsUpdate():
-					c.expirePolicy.Delete(t.OldNode())
-					c.expirePolicy.Add(t.Node())
-				}
-			}
-
-			d := c.policy.Write(deleted, buffer)
-			for _, n := range d {
-				c.expirePolicy.Delete(n)
-			}
-
-			c.evictionMutex.Unlock()
-
-			for _, n := range d {
-				c.hashmap.EvictNode(n)
-			}
-
-			buffer = clearBuffer(buffer)
-			deleted = clearBuffer(deleted)
-		}
-	}
-}
-
-// Range iterates over all items in the cache.
-//
-// Iteration stops early when the given function returns false.
-func (c *Cache[K, V]) Range(f func(key K, value V) bool) {
-	c.hashmap.Range(func(n *node.Node[K, V]) bool {
-		if n.IsExpired() {
-			return true
-		}
-
-		return f(n.Key(), n.Value())
-	})
-}
-
-// Clear clears the hash table, all policies, buffers, etc.
-//
-// NOTE: this operation must be performed when no requests are made to the cache otherwise the behavior is undefined.
-func (c *Cache[K, V]) Clear() {
-	c.clear(node.NewClearTask[K, V]())
-}
-
-func (c *Cache[K, V]) clear(task node.WriteTask[K, V]) {
-	c.hashmap.Clear()
-	for i := 0; i < len(c.readBuffers); i++ {
-		c.readBuffers[i].Clear()
-	}
-
-	c.writeBuffer.Insert(task)
-	<-c.doneClear
-
-	c.stats.Clear()
-}
-
-// Close clears the hash table, all policies, buffers, etc and stop all goroutines.
-//
-// NOTE: this operation must be performed when no requests are made to the cache otherwise the behavior is undefined.
-func (c *Cache[K, V]) Close() {
-	c.closeOnce.Do(func() {
-		c.clear(node.NewCloseTask[K, V]())
-		unixtime.Stop()
-	})
-}
-
-// Size returns the current number of items in the cache.
-func (c *Cache[K, V]) Size() int {
-	return c.hashmap.Size()
-}
-
-// Capacity returns the cache capacity.
-func (c *Cache[K, V]) Capacity() int {
-	return c.capacity
-}
-
-// Hits returns the number of cache hits.
-func (c *Cache[K, V]) Hits() int64 {
-	return c.stats.Hits()
-}
-
-// Misses returns the number of cache misses.
-func (c *Cache[K, V]) Misses() int64 {
-	return c.stats.Misses()
-}
-
-// Ratio returns the cache hit ratio.
-func (c *Cache[K, V]) Ratio() float64 {
-	return c.stats.Ratio()
-}
-
-func clearBuffer[T any](buffer []T) []T {
-	var zero T
-	for i := 0; i < len(buffer); i++ {
-		buffer[i] = zero
-	}
-	return buffer[:0]
+// If it returns false, then the key-value item had too much cost and the Set was dropped.
+func (c CacheWithVariableTTL[K, V]) Set(key K, value V, ttl time.Duration) bool {
+	return c.cache.SetWithTTL(key, value, ttl)
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -22,23 +22,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/maypok86/otter/internal/node"
 	"github.com/maypok86/otter/internal/xruntime"
 )
 
 func TestCache_Set(t *testing.T) {
-	b, err := NewBuilder[int, int](100)
-	if err != nil {
-		t.Fatalf("can not create builder: %v", err)
-	}
-
-	c, err := b.StatsEnabled(true).Build()
+	c, err := MustBuilder[int, int](100).WithTTL(time.Minute).CollectStats().Build()
 	if err != nil {
 		t.Fatalf("can not create cache: %v", err)
 	}
 
 	for i := 0; i < 100; i++ {
-		c.SetWithTTL(i, i, time.Minute)
+		c.Set(i, i)
 	}
 
 	parallelism := xruntime.Parallelism()
@@ -68,7 +62,7 @@ func TestCache_Set(t *testing.T) {
 	if err != nil {
 		t.Fatalf("not found key: %v", err)
 	}
-	ratio := c.Ratio()
+	ratio := c.Stats().Ratio()
 	if ratio != 1.0 {
 		t.Fatalf("cache hit ratio should be 1.0, but got %v", ratio)
 	}
@@ -76,13 +70,13 @@ func TestCache_Set(t *testing.T) {
 
 func TestCache_SetWithTTL(t *testing.T) {
 	size := 256
-	c, err := MustBuilder[int, int](size).Build()
+	c, err := MustBuilder[int, int](size).WithTTL(time.Second).Build()
 	if err != nil {
 		t.Fatalf("can not create builder: %v", err)
 	}
 
 	for i := 0; i < size; i++ {
-		c.SetWithTTL(i, i, time.Second)
+		c.Set(i, i)
 	}
 
 	time.Sleep(3 * time.Second)
@@ -98,65 +92,35 @@ func TestCache_SetWithTTL(t *testing.T) {
 		t.Fatalf("c.Size() = %d, want = %d", cacheSize, 0)
 	}
 
-	c, err = MustBuilder[int, int](size).Build()
+	cc, err := MustBuilder[int, int](size).WithVariableTTL().CollectStats().Build()
 	if err != nil {
 		t.Fatalf("can not create builder: %v", err)
 	}
 
 	for i := 0; i < size; i++ {
-		c.SetWithTTL(i, i, 5*time.Second)
+		cc.Set(i, i, 5*time.Second)
 	}
 
 	time.Sleep(7 * time.Second)
 
 	for i := 0; i < size; i++ {
-		if c.Has(i) {
+		if cc.Has(i) {
 			t.Fatalf("key should be expired: %d", i)
 		}
 	}
 
 	time.Sleep(10 * time.Millisecond)
 
-	if cacheSize := c.Size(); cacheSize != 0 {
+	if cacheSize := cc.Size(); cacheSize != 0 {
 		t.Fatalf("c.Size() = %d, want = %d", cacheSize, 0)
 	}
-}
-
-func TestCache_SetWithCost(t *testing.T) {
-	size := 10
-	c, err := MustBuilder[int, int](size).Cost(func(key int, value int) uint32 {
-		return uint32(key)
-	}).Build()
-	if err != nil {
-		t.Fatalf("can not create cache: %v", err)
-	}
-
-	goodCost := int(c.policy.MaxAvailableCost())
-	badCost := goodCost + 1
-
-	added := c.Set(goodCost, 1)
-	if !added {
-		t.Fatalf("Set was dropped, even though it shouldn't have been. Max available cost: %d, actual cost: %d",
-			c.policy.MaxAvailableCost(),
-			c.costFunc(goodCost, 1),
-		)
-	}
-	added = c.Set(badCost, 1)
-	if added {
-		t.Fatalf("Set wasn't dropped, though it should have been. Max available cost: %d, actual cost: %d",
-			c.policy.MaxAvailableCost(),
-			c.costFunc(badCost, 1),
-		)
+	if misses := cc.Stats().Misses(); misses != int64(size) {
+		t.Fatalf("c.Stats().Misses() = %d, want = %d", misses, size)
 	}
 }
 
 func TestCache_Ratio(t *testing.T) {
-	b, err := NewBuilder[uint64, uint64](100)
-	if err != nil {
-		t.Fatalf("can not create builder: %v", err)
-	}
-
-	c, err := b.StatsEnabled(true).Build()
+	c, err := MustBuilder[uint64, uint64](100).CollectStats().Build()
 	if err != nil {
 		t.Fatalf("can not create cache: %v", err)
 	}
@@ -174,97 +138,7 @@ func TestCache_Ratio(t *testing.T) {
 	}
 
 	t.Logf("actual size: %d, capacity: %d", c.Size(), c.Capacity())
-	t.Logf("actual: %.2f, optimal: %.2f", c.Ratio(), o.Ratio())
-}
-
-func TestCache_Range(t *testing.T) {
-	size := 10
-	c, err := MustBuilder[int, int](size).Build()
-	if err != nil {
-		t.Fatalf("can not create cache: %v", err)
-	}
-
-	time.Sleep(3 * time.Second)
-
-	c.Set(1, 1)
-	c.hashmap.Set(node.New(2, 2, 1, 1))
-	c.Set(3, 3)
-	aliveNodes := 2
-	iters := 0
-	c.Range(func(key, value int) bool {
-		if key != value {
-			t.Fatalf("got unexpected key/value for iteration %d: %d/%d", iters, key, value)
-			return false
-		}
-		iters++
-		return true
-	})
-	if iters != aliveNodes {
-		t.Fatalf("got unexpected number of iterations: %d", iters)
-	}
-}
-
-func TestCache_Close(t *testing.T) {
-	size := 10
-	c, err := MustBuilder[int, int](size).Build()
-	if err != nil {
-		t.Fatalf("can not create cache: %v", err)
-	}
-
-	for i := 0; i < size; i++ {
-		c.Set(i, i)
-	}
-
-	if cacheSize := c.Size(); cacheSize != size {
-		t.Fatalf("c.Size() = %d, want = %d", cacheSize, size)
-	}
-
-	c.Close()
-
-	time.Sleep(10 * time.Millisecond)
-
-	if cacheSize := c.Size(); cacheSize != 0 {
-		t.Fatalf("c.Size() = %d, want = %d", cacheSize, 0)
-	}
-	if !c.isClosed {
-		t.Fatalf("cache should be closed")
-	}
-
-	c.Close()
-
-	if cacheSize := c.Size(); cacheSize != 0 {
-		t.Fatalf("c.Size() = %d, want = %d", cacheSize, 0)
-	}
-	if !c.isClosed {
-		t.Fatalf("cache should be closed")
-	}
-}
-
-func TestCache_Clear(t *testing.T) {
-	size := 10
-	c, err := MustBuilder[int, int](size).Build()
-	if err != nil {
-		t.Fatalf("can not create cache: %v", err)
-	}
-
-	for i := 0; i < size; i++ {
-		c.Set(i, i)
-	}
-
-	if cacheSize := c.Size(); cacheSize != size {
-		t.Fatalf("c.Size() = %d, want = %d", cacheSize, size)
-	}
-
-	c.Clear()
-
-	time.Sleep(10 * time.Millisecond)
-
-	if cacheSize := c.Size(); cacheSize != 0 {
-		t.Fatalf("c.Size() = %d, want = %d", cacheSize, 0)
-	}
-	if c.isClosed {
-		t.Fatalf("cache shouldn't be closed")
-	}
+	t.Logf("actual: %.2f, optimal: %.2f", c.Stats().Ratio(), o.Ratio())
 }
 
 type optimal struct {

--- a/internal/core/cache.go
+++ b/internal/core/cache.go
@@ -1,0 +1,346 @@
+// Copyright (c) 2023 Alexey Mayshev. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"sync"
+	"time"
+
+	"github.com/maypok86/otter/internal/expire"
+	"github.com/maypok86/otter/internal/hashtable"
+	"github.com/maypok86/otter/internal/lossy"
+	"github.com/maypok86/otter/internal/node"
+	"github.com/maypok86/otter/internal/queue"
+	"github.com/maypok86/otter/internal/s3fifo"
+	"github.com/maypok86/otter/internal/stats"
+	"github.com/maypok86/otter/internal/unixtime"
+	"github.com/maypok86/otter/internal/xmath"
+	"github.com/maypok86/otter/internal/xruntime"
+)
+
+func zeroValue[V any]() V {
+	var zero V
+	return zero
+}
+
+// Config is a set of cache settings.
+type Config[K comparable, V any] struct {
+	Capacity        int
+	StatsEnabled    bool
+	TTL             *time.Duration
+	WithVariableTTL bool
+	CostFunc        func(key K, value V) uint32
+}
+
+// Cache is a structure performs a best-effort bounding of a hash table using eviction algorithm
+// to determine which entries to evict when the capacity is exceeded.
+type Cache[K comparable, V any] struct {
+	hashmap       *hashtable.Map[K, V]
+	policy        *s3fifo.Policy[K, V]
+	expirePolicy  *expire.Policy[K, V]
+	stats         *stats.Stats
+	readBuffers   []*lossy.Buffer[node.Node[K, V]]
+	writeBuffer   *queue.MPSC[node.WriteTask[K, V]]
+	evictionMutex sync.Mutex
+	closeOnce     sync.Once
+	isClosed      bool
+	doneClear     chan struct{}
+	costFunc      func(key K, value V) uint32
+	ttl           uint32
+	capacity      int
+	mask          uint32
+}
+
+// NewCache returns a new cache instance based on the settings from Config.
+func NewCache[K comparable, V any](c Config[K, V]) *Cache[K, V] {
+	parallelism := xruntime.Parallelism()
+	roundedParallelism := int(xmath.RoundUpPowerOf2(parallelism))
+	writeBufferCapacity := 128 * roundedParallelism
+	readBuffersCount := 4 * roundedParallelism
+
+	readBuffers := make([]*lossy.Buffer[node.Node[K, V]], 0, readBuffersCount)
+	for i := 0; i < readBuffersCount; i++ {
+		readBuffers = append(readBuffers, lossy.New[node.Node[K, V]]())
+	}
+
+	cache := &Cache[K, V]{
+		hashmap:     hashtable.New[K, V](),
+		policy:      s3fifo.NewPolicy[K, V](uint32(c.Capacity)),
+		readBuffers: readBuffers,
+		writeBuffer: queue.NewMPSC[node.WriteTask[K, V]](writeBufferCapacity),
+		doneClear:   make(chan struct{}),
+		mask:        uint32(readBuffersCount - 1),
+		costFunc:    c.CostFunc,
+		capacity:    c.Capacity,
+	}
+
+	cache.expirePolicy = expire.NewPolicy[K, V]()
+	if c.StatsEnabled {
+		cache.stats = stats.New()
+	}
+	if c.TTL != nil {
+		cache.ttl = uint32((*c.TTL + time.Second - 1) / time.Second)
+	}
+
+	unixtime.Start()
+	go cache.process()
+	go cache.cleanup()
+
+	return cache
+}
+
+func (c *Cache[K, V]) getReadBufferIdx() int {
+	return int(xruntime.Fastrand() & c.mask)
+}
+
+// Has checks if there is an item with the given key in the cache.
+func (c *Cache[K, V]) Has(key K) bool {
+	_, ok := c.Get(key)
+	return ok
+}
+
+// Get returns the value associated with the key in this cache.
+func (c *Cache[K, V]) Get(key K) (V, bool) {
+	got, ok := c.hashmap.Get(key)
+	if !ok {
+		c.stats.IncMisses()
+		return zeroValue[V](), false
+	}
+
+	if got.IsExpired() {
+		c.writeBuffer.Insert(node.NewDeleteTask(got))
+		c.stats.IncMisses()
+		return zeroValue[V](), false
+	}
+
+	c.afterGet(got)
+	c.stats.IncHits()
+
+	return got.Value(), ok
+}
+
+func (c *Cache[K, V]) afterGet(got *node.Node[K, V]) {
+	idx := c.getReadBufferIdx()
+	pb := c.readBuffers[idx].Add(got)
+	if pb != nil {
+		c.evictionMutex.Lock()
+		c.policy.Read(pb.Returned)
+		c.evictionMutex.Unlock()
+
+		c.readBuffers[idx].Free()
+	}
+}
+
+// Set associates the value with the key in this cache.
+//
+// If it returns false, then the key-value item had too much cost and the Set was dropped.
+func (c *Cache[K, V]) Set(key K, value V) bool {
+	return c.set(key, value, c.defaultExpiration())
+}
+
+func (c *Cache[K, V]) defaultExpiration() uint32 {
+	if c.ttl == 0 {
+		return 0
+	}
+
+	return unixtime.Now() + c.ttl
+}
+
+// SetWithTTL associates the value with the key in this cache and sets the custom ttl for this key-value item.
+//
+// If it returns false, then the key-value item had too much cost and the SetWithTTL was dropped.
+func (c *Cache[K, V]) SetWithTTL(key K, value V, ttl time.Duration) bool {
+	ttl = (ttl + time.Second - 1) / time.Second
+	expiration := unixtime.Now() + uint32(ttl)
+	return c.set(key, value, expiration)
+}
+
+func (c *Cache[K, V]) set(key K, value V, expiration uint32) bool {
+	cost := c.costFunc(key, value)
+	if cost > c.policy.MaxAvailableCost() {
+		return false
+	}
+
+	n := node.New(key, value, expiration, cost)
+	evicted := c.hashmap.Set(n)
+	if evicted != nil {
+		// update
+		c.writeBuffer.Insert(node.NewUpdateTask(n, evicted))
+	} else {
+		// insert
+		c.writeBuffer.Insert(node.NewAddTask(n))
+	}
+
+	return true
+}
+
+// Delete removes the association for this key from the cache.
+func (c *Cache[K, V]) Delete(key K) {
+	deleted := c.hashmap.Delete(key)
+	if deleted != nil {
+		c.writeBuffer.Insert(node.NewDeleteTask(deleted))
+	}
+}
+
+func (c *Cache[K, V]) cleanup() {
+	expired := make([]*node.Node[K, V], 0, 128)
+	for {
+		time.Sleep(time.Second)
+
+		c.evictionMutex.Lock()
+		if c.isClosed {
+			return
+		}
+
+		e := c.expirePolicy.RemoveExpired(expired)
+		c.policy.Delete(e)
+
+		c.evictionMutex.Unlock()
+
+		for _, n := range e {
+			c.hashmap.EvictNode(n)
+		}
+
+		expired = clearBuffer(expired)
+	}
+}
+
+func (c *Cache[K, V]) process() {
+	bufferCapacity := 64
+	buffer := make([]node.WriteTask[K, V], 0, bufferCapacity)
+	deleted := make([]*node.Node[K, V], 0, bufferCapacity)
+	i := 0
+	for {
+		task := c.writeBuffer.Remove()
+
+		if task.IsClear() || task.IsClose() {
+			buffer = clearBuffer(buffer)
+			c.writeBuffer.Clear()
+
+			c.evictionMutex.Lock()
+			c.policy.Clear()
+			c.expirePolicy.Clear()
+			if task.IsClose() {
+				c.isClosed = true
+			}
+			c.evictionMutex.Unlock()
+
+			c.doneClear <- struct{}{}
+			if task.IsClose() {
+				break
+			}
+			continue
+		}
+
+		buffer = append(buffer, task)
+		i++
+		if i >= bufferCapacity {
+			i -= bufferCapacity
+
+			c.evictionMutex.Lock()
+
+			for _, t := range buffer {
+				switch {
+				case t.IsDelete():
+					c.expirePolicy.Delete(t.Node())
+				case t.IsAdd():
+					c.expirePolicy.Add(t.Node())
+				case t.IsUpdate():
+					c.expirePolicy.Delete(t.OldNode())
+					c.expirePolicy.Add(t.Node())
+				}
+			}
+
+			d := c.policy.Write(deleted, buffer)
+			for _, n := range d {
+				c.expirePolicy.Delete(n)
+			}
+
+			c.evictionMutex.Unlock()
+
+			for _, n := range d {
+				c.hashmap.EvictNode(n)
+			}
+
+			buffer = clearBuffer(buffer)
+			deleted = clearBuffer(deleted)
+		}
+	}
+}
+
+// Range iterates over all items in the cache.
+//
+// Iteration stops early when the given function returns false.
+func (c *Cache[K, V]) Range(f func(key K, value V) bool) {
+	c.hashmap.Range(func(n *node.Node[K, V]) bool {
+		if n.IsExpired() {
+			return true
+		}
+
+		return f(n.Key(), n.Value())
+	})
+}
+
+// Clear clears the hash table, all policies, buffers, etc.
+//
+// NOTE: this operation must be performed when no requests are made to the cache otherwise the behavior is undefined.
+func (c *Cache[K, V]) Clear() {
+	c.clear(node.NewClearTask[K, V]())
+}
+
+func (c *Cache[K, V]) clear(task node.WriteTask[K, V]) {
+	c.hashmap.Clear()
+	for i := 0; i < len(c.readBuffers); i++ {
+		c.readBuffers[i].Clear()
+	}
+
+	c.writeBuffer.Insert(task)
+	<-c.doneClear
+
+	c.stats.Clear()
+}
+
+// Close clears the hash table, all policies, buffers, etc and stop all goroutines.
+//
+// NOTE: this operation must be performed when no requests are made to the cache otherwise the behavior is undefined.
+func (c *Cache[K, V]) Close() {
+	c.closeOnce.Do(func() {
+		c.clear(node.NewCloseTask[K, V]())
+		unixtime.Stop()
+	})
+}
+
+// Size returns the current number of items in the cache.
+func (c *Cache[K, V]) Size() int {
+	return c.hashmap.Size()
+}
+
+// Capacity returns the cache capacity.
+func (c *Cache[K, V]) Capacity() int {
+	return c.capacity
+}
+
+// Stats returns a current snapshot of this cache's cumulative statistics.
+func (c *Cache[K, V]) Stats() *stats.Stats {
+	return c.stats
+}
+
+func clearBuffer[T any](buffer []T) []T {
+	var zero T
+	for i := 0; i < len(buffer); i++ {
+		buffer[i] = zero
+	}
+	return buffer[:0]
+}

--- a/internal/core/cache_test.go
+++ b/internal/core/cache_test.go
@@ -1,0 +1,132 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maypok86/otter/internal/node"
+)
+
+func TestCache_SetWithCost(t *testing.T) {
+	size := 10
+	c := NewCache[int, int](Config[int, int]{
+		Capacity: size,
+		CostFunc: func(key int, value int) uint32 {
+			return uint32(key)
+		},
+	})
+
+	goodCost := int(c.policy.MaxAvailableCost())
+	badCost := goodCost + 1
+
+	added := c.Set(goodCost, 1)
+	if !added {
+		t.Fatalf("Set was dropped, even though it shouldn't have been. Max available cost: %d, actual cost: %d",
+			c.policy.MaxAvailableCost(),
+			c.costFunc(goodCost, 1),
+		)
+	}
+	added = c.Set(badCost, 1)
+	if added {
+		t.Fatalf("Set wasn't dropped, though it should have been. Max available cost: %d, actual cost: %d",
+			c.policy.MaxAvailableCost(),
+			c.costFunc(badCost, 1),
+		)
+	}
+}
+
+func TestCache_Range(t *testing.T) {
+	size := 10
+	c := NewCache[int, int](Config[int, int]{
+		Capacity: size,
+		CostFunc: func(key int, value int) uint32 {
+			return 1
+		},
+	})
+
+	time.Sleep(3 * time.Second)
+
+	c.Set(1, 1)
+	c.hashmap.Set(node.New(2, 2, 1, 1))
+	c.Set(3, 3)
+	aliveNodes := 2
+	iters := 0
+	c.Range(func(key, value int) bool {
+		if key != value {
+			t.Fatalf("got unexpected key/value for iteration %d: %d/%d", iters, key, value)
+			return false
+		}
+		iters++
+		return true
+	})
+	if iters != aliveNodes {
+		t.Fatalf("got unexpected number of iterations: %d", iters)
+	}
+}
+
+func TestCache_Close(t *testing.T) {
+	size := 10
+	c := NewCache[int, int](Config[int, int]{
+		Capacity: size,
+		CostFunc: func(key int, value int) uint32 {
+			return 1
+		},
+	})
+
+	for i := 0; i < size; i++ {
+		c.Set(i, i)
+	}
+
+	if cacheSize := c.Size(); cacheSize != size {
+		t.Fatalf("c.Size() = %d, want = %d", cacheSize, size)
+	}
+
+	c.Close()
+
+	time.Sleep(10 * time.Millisecond)
+
+	if cacheSize := c.Size(); cacheSize != 0 {
+		t.Fatalf("c.Size() = %d, want = %d", cacheSize, 0)
+	}
+	if !c.isClosed {
+		t.Fatalf("cache should be closed")
+	}
+
+	c.Close()
+
+	if cacheSize := c.Size(); cacheSize != 0 {
+		t.Fatalf("c.Size() = %d, want = %d", cacheSize, 0)
+	}
+	if !c.isClosed {
+		t.Fatalf("cache should be closed")
+	}
+}
+
+func TestCache_Clear(t *testing.T) {
+	size := 10
+	c := NewCache[int, int](Config[int, int]{
+		Capacity: size,
+		CostFunc: func(key int, value int) uint32 {
+			return 1
+		},
+	})
+
+	for i := 0; i < size; i++ {
+		c.Set(i, i)
+	}
+
+	if cacheSize := c.Size(); cacheSize != size {
+		t.Fatalf("c.Size() = %d, want = %d", cacheSize, size)
+	}
+
+	c.Clear()
+
+	time.Sleep(10 * time.Millisecond)
+
+	if cacheSize := c.Size(); cacheSize != 0 {
+		t.Fatalf("c.Size() = %d, want = %d", cacheSize, 0)
+	}
+	if c.isClosed {
+		t.Fatalf("cache shouldn't be closed")
+	}
+}


### PR DESCRIPTION
## Problem

Now otter uses an api very similar to other go cache libraries, but unfortunately it is not particularly beautiful and extensible.

For example, now we have `Set(key, value)` and `SetWithTTL(key, value, ttl)` functions, but if we want to add `SetIfAbsent(key, value)` function, we also need `SetIfAbsentWithTTL(key, value, ttl)` function, which doesn't look nice anymore.

## Solution

Implement a more advanced version of the builder and a set of cache wrappers.

## Related issue(s)
- Resolves #40

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
    - [x] If I added new functionality, I added tests covering it.
    - [x] If I fixed a bug, I added a regression test to prevent the bug from
      silently reappearing again.

- Documentation
    - [x] I checked whether I should update the docs and did so if necessary:
        - [README](../README.md)

- Public contracts
    - [x] My changes doesn't break project license.

#### Stylistic guide (mandatory)

- [x] My code complies with the [styles guide](https://github.com/uber-go/guide/blob/master/style.md).
- [x] My commit history is clean (only contains changes relating to my
  issue/pull request and no reverted-my-earlier-commit changes) and commit
  messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).

#### Before merging (mandatory)
- [x] Check __target__  branch of PR is set correctly
