### PR TITLE
[#27] Add SetIfAbsent function

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -125,6 +125,15 @@ func (c Cache[K, V]) Set(key K, value V) bool {
 	return c.cache.Set(key, value)
 }
 
+// SetIfAbsent if the specified key is not already associated with a value associates it with the given value.
+//
+// If the specified key is not already associated with a value, then it returns false.
+//
+// Also, it returns false if the key-value item had too much cost and the SetIfAbsent was dropped.
+func (c Cache[K, V]) SetIfAbsent(key K, value V) bool {
+	return c.cache.SetIfAbsent(key, value)
+}
+
 // CacheWithVariableTTL is a structure performs a best-effort bounding of a hash table using eviction algorithm
 // to determine which entries to evict when the capacity is exceeded.
 type CacheWithVariableTTL[K comparable, V any] struct {
@@ -142,4 +151,14 @@ func newCacheWithVariableTTL[K comparable, V any](c core.Config[K, V]) CacheWith
 // If it returns false, then the key-value item had too much cost and the Set was dropped.
 func (c CacheWithVariableTTL[K, V]) Set(key K, value V, ttl time.Duration) bool {
 	return c.cache.SetWithTTL(key, value, ttl)
+}
+
+// SetIfAbsent if the specified key is not already associated with a value associates it with the given value
+// and sets the custom ttl for this key-value item.
+//
+// If the specified key is not already associated with a value, then it returns false.
+//
+// Also, it returns false if the key-value item had too much cost and the SetIfAbsent was dropped.
+func (c CacheWithVariableTTL[K, V]) SetIfAbsent(key K, value V, ttl time.Duration) bool {
+	return c.cache.SetIfAbsentWithTTL(key, value, ttl)
 }

--- a/internal/hashtable/map_test.go
+++ b/internal/hashtable/map_test.go
@@ -86,6 +86,34 @@ func TestMap_Set(t *testing.T) {
 	}
 }
 
+func TestMap_SetIfAbsent(t *testing.T) {
+	const numberOfNodes = 128
+	m := New[string, int]()
+	for i := 0; i < numberOfNodes; i++ {
+		res := m.SetIfAbsent(newNode[string, int](strconv.Itoa(i), i))
+		if res != nil {
+			t.Fatalf("set was dropped. got: %+v", res)
+		}
+	}
+	for i := 0; i < numberOfNodes; i++ {
+		n := newNode[string, int](strconv.Itoa(i), i)
+		res := m.SetIfAbsent(n)
+		if res == nil {
+			t.Fatalf("set was not dropped. node that was set: %+v", res)
+		}
+	}
+
+	for i := 0; i < numberOfNodes; i++ {
+		n, ok := m.Get(strconv.Itoa(i))
+		if !ok {
+			t.Fatalf("value not found for %d", i)
+		}
+		if n.Value() != i {
+			t.Fatalf("values do not match for %d: %v", i, n.Value())
+		}
+	}
+}
+
 // this code may break if the maphash.Hasher[k] structure changes.
 type hasher struct {
 	hash func(pointer unsafe.Pointer, seed uintptr) uintptr
@@ -372,7 +400,7 @@ func parallelTypedRangeDeleter(t *testing.T, m *Map[int, int], numNodes int, sto
 	cdone <- true
 }
 
-func TestMapOfParallelRange(t *testing.T) {
+func TestMap_ParallelRange(t *testing.T) {
 	const numNodes = 10_000
 	m := New[int, int]()
 	for i := 0; i < numNodes; i++ {

--- a/internal/s3fifo/policy.go
+++ b/internal/s3fifo/policy.go
@@ -78,7 +78,7 @@ func (p *Policy[K, V]) evict(deleted []*node.Node[K, V]) []*node.Node[K, V] {
 }
 
 func (p *Policy[K, V]) isFull() bool {
-	return p.small.cost+p.main.cost >= p.maxCost
+	return p.small.cost+p.main.cost > p.maxCost
 }
 
 // Write updates the eviction policy based on node updates.

--- a/internal/s3fifo/policy_test.go
+++ b/internal/s3fifo/policy_test.go
@@ -111,7 +111,7 @@ func TestPolicy_Update(t *testing.T) {
 
 	p.Read([]*node.Node[int, int]{n1, n1})
 
-	n2 := node.New[int, int](2, 1, 0, 91)
+	n2 := node.New[int, int](2, 1, 0, 92)
 	deleted := p.Write(nil, []node.WriteTask[int, int]{
 		node.NewAddTask(n2),
 	})


### PR DESCRIPTION
## Description

1. Added `SetIfAbsent(key, value)` function for cache without or constant TTL
2. Added `SetIfAbsent(key, value, ttl)` function for cache with variable TTL

## Related issue(s)

- Resolves #27 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
    - [x] If I added new functionality, I added tests covering it.
    - [x] If I fixed a bug, I added a regression test to prevent the bug from
      silently reappearing again.

- Documentation
    - [x] I checked whether I should update the docs and did so if necessary:
        - [README](../README.md)

- Public contracts
    - [x] My changes doesn't break project license.

#### Stylistic guide (mandatory)

- [x] My code complies with the [styles guide](https://github.com/uber-go/guide/blob/master/style.md).
- [x] My commit history is clean (only contains changes relating to my
  issue/pull request and no reverted-my-earlier-commit changes) and commit
  messages start with identifiers of related issues in square brackets.

  **Example:** `[#42] Short commit description`

  If necessary both of these can be achieved even after the commits have been
  made/pushed using [rebase and squash](https://git-scm.com/docs/git-rebase).

#### Before merging (mandatory)
- [x] Check __target__  branch of PR is set correctly
