### PR TITLE
Remove Time.Sleep when do cleanup

### DIFF
--- a/internal/core/cache.go
+++ b/internal/core/cache.go
@@ -349,9 +349,10 @@ func (c *Cache[K, V]) notifyDeletion(key K, value V, cause DeletionCause) {
 func (c *Cache[K, V]) cleanup() {
 	bufferCapacity := 64
 	expired := make([]node.Node[K, V], 0, bufferCapacity)
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
 	for {
-		time.Sleep(time.Second)
-
+		_ = <-ticker.C
 		c.evictionMutex.Lock()
 		if c.isClosed {
 			return


### PR DESCRIPTION
## Description
1. **More Accurate Timing**: `time.Sleep` puts the current goroutine to sleep and then wakes it up after the specified time. The actual sleep duration might be slightly longer than specified due to the goroutine needing to wait for the Go scheduler to schedule it for execution again. `time.Ticker`, on the other hand, maintains a steady rate of emitting signals. While it is still subject to the scheduler's influence, it tries to compensate for any time discrepancies to maintain accurate intervals.

2. **Better Resource Management**: With `time.Ticker`, you can stop it when the timer is no longer needed, freeing up associated resources. This is done by calling the `ticker.Stop()` method. `time.Sleep` does not offer such a mechanism; once called, it will sleep for the specified duration, even if your program needs to stop waiting during that period.

3. **CPU Time Savings**: When using `time.Sleep`, if your program is in a tight loop, it may incur unnecessary CPU overhead by repeatedly asking the scheduler to put it to sleep and then wake it up after each iteration. `time.Ticker` uses a fixed rate, reducing this overhead since it uses optimized mechanisms internally to manage timed events.

Overall, `time.Ticker` provides a more flexible, accurate, and efficient way to handle repetitive time interval controls, especially in scenarios that require precise control and resource management.

