### PR TITLE
fix: use context.WithoutCancel for refreshes (#124)

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -124,6 +124,10 @@ func (c *Cache[K, V]) SetRefreshableAfter(key K, refreshableAfter time.Duration)
 //
 // No observable state associated with this cache is modified until loading completes.
 //
+// WARNING: When performing a refresh (see [RefreshCalculator]),
+// the [Loader] will receive a context wrapped in [context.WithoutCancel].
+// If you need to control refresh cancellation, you can use closures or values stored in the context.
+//
 // WARNING: [Loader] must not attempt to update any mappings of this cache directly.
 //
 // WARNING: For any given key, every loader used with it should compute the same value.
@@ -145,6 +149,10 @@ func (c *Cache[K, V]) Get(ctx context.Context, key K, loader Loader[K, V]) (V, e
 // No observable state associated with this cache is modified until loading completes.
 //
 // NOTE: duplicate elements in keys will be ignored.
+//
+// WARNING: When performing a refresh (see [RefreshCalculator]),
+// the [BulkLoader] will receive a context wrapped in [context.WithoutCancel].
+// If you need to control refresh cancellation, you can use closures or values stored in the context.
 //
 // WARNING: [BulkLoader] must not attempt to update any mappings of this cache directly.
 //
@@ -169,6 +177,10 @@ func (c *Cache[K, V]) BulkGet(ctx context.Context, keys []K, bulkLoader BulkLoad
 // Loading is asynchronous by delegating to the configured Executor.
 //
 // Refresh returns a channel that will receive the result when it is ready. The returned channel will not be closed.
+//
+// WARNING: When performing a refresh (see [RefreshCalculator]),
+// the [Loader] will receive a context wrapped in [context.WithoutCancel].
+// If you need to control refresh cancellation, you can use closures or values stored in the context.
 //
 // WARNING: If the cache was constructed without [RefreshCalculator], then Refresh will return the nil channel.
 //
@@ -196,6 +208,10 @@ func (c *Cache[K, V]) Refresh(ctx context.Context, key K, loader Loader[K, V]) <
 // BulkRefresh returns a channel that will receive the results when they are ready. The returned channel will not be closed.
 //
 // NOTE: duplicate elements in keys will be ignored.
+//
+// WARNING: When performing a refresh (see [RefreshCalculator]),
+// the [BulkLoader] will receive a context wrapped in [context.WithoutCancel].
+// If you need to control refresh cancellation, you can use closures or values stored in the context.
 //
 // WARNING: If the cache was constructed without [RefreshCalculator], then BulkRefresh will return the nil channel.
 //


### PR DESCRIPTION
## Description

This PR prevents cancellation of refresh execution via context cancellation.

## Related issue(s)

#124 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
    - [ ] If I added new functionality, I added tests covering it.
    - [ ] If I fixed a bug, I added a regression test to prevent the bug from
      silently reappearing again.

- Documentation
    - [ ] I checked whether I should update the docs and did so if necessary:
        - [README](../README.md)

- Public contracts
    - [ ] My changes doesn't break project license.

#### Stylistic guide (mandatory)

- [ ] My code complies with the [styles guide](https://github.com/uber-go/guide/blob/master/style.md).

#### Before merging (mandatory)
- [ ] Check __target__  branch of PR is set correctly
