### PR TITLE
fix: panic when concurrent invalidate all and get with loader

### DIFF
--- a/internal/deque/queue/mpsc.go
+++ b/internal/deque/queue/mpsc.go
@@ -215,6 +215,9 @@ func (m *MPSC[T]) TryPop() *T {
 }
 
 func (m *MPSC[T]) Size() uint64 {
+	if m == nil {
+		return 0
+	}
 	// NOTE: because indices are on even numbers we cannot use the size util.
 
 	// It is possible for a thread to be interrupted or reschedule between the read of the producer

--- a/internal/hashmap/map.go
+++ b/internal/hashmap/map.go
@@ -599,7 +599,7 @@ func (table *mapTable[K]) sumSize() int64 {
 	for i := range table.size {
 		sum += atomic.LoadInt64(&table.size[i].c)
 	}
-	return sum
+	return max(sum, 0)
 }
 
 func h1(h uint64) uint64 {

--- a/issue_test.go
+++ b/issue_test.go
@@ -17,9 +17,9 @@ package otter
 import (
 	"context"
 	"fmt"
-	"testing"
-
 	"github.com/stretchr/testify/require"
+	"sync"
+	"testing"
 )
 
 type triple struct {
@@ -60,4 +60,40 @@ func TestCache_Issue132(t *testing.T) {
 	require.Equal(t, 3, value3.a)
 	require.Equal(t, 4, value3.b)
 	require.Equal(t, 2, accessCounter)
+}
+
+// https://github.com/maypok86/otter/issues/139
+func TestCache_Issue139(t *testing.T) {
+	t.Parallel()
+
+	cache := Must(&Options[string, string]{})
+
+	loader := func(ctx context.Context, key string) (string, error) {
+		return "v1", nil
+	}
+
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < 10000000; i++ {
+			cache.InvalidateAll()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < 10000000; i++ {
+			v, _ := cache.Get(context.Background(), "v1", LoaderFunc[string, string](loader))
+			if v != "v1" {
+				t.Errorf("expected v1, got %s", v)
+			}
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
## Description

This panic appears to be caused by xsync.Map's [size increment](https://github.com/puzpuzpuz/xsync/blob/v4.1.0/map.go#L491) happening after mutex.Unlock, which under high contention can result in a negative value being returned.

## Related issue(s)

- #139 

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
    - [ ] If I added new functionality, I added tests covering it.
    - [ ] If I fixed a bug, I added a regression test to prevent the bug from
      silently reappearing again.

- Documentation
    - [ ] I checked whether I should update the docs and did so if necessary:
        - [README](../README.md)

- Public contracts
    - [ ] My changes doesn't break project license.

#### Stylistic guide (mandatory)

- [ ] My code complies with the [styles guide](https://github.com/uber-go/guide/blob/master/style.md).

#### Before merging (mandatory)
- [ ] Check __target__  branch of PR is set correctly
