### PR TITLE
fix: treat expired item refresh as create operation in ExpiryCreating

### DIFF
--- a/cache_impl.go
+++ b/cache_impl.go
@@ -414,7 +414,7 @@ func (c *cache[K, V]) calcExpiresAtAfterWrite(n, old node.Node[K, V], nowNano in
 	entry := c.nodeToEntry(n, nowNano)
 	currentDuration := entry.ExpiresAfter()
 	var expiresAfter time.Duration
-	if old == nil {
+	if old == nil || old.HasExpired(nowNano) {
 		expiresAfter = c.expiryCalculator.ExpireAfterCreate(entry)
 	} else {
 		expiresAfter = c.expiryCalculator.ExpireAfterUpdate(entry, old.Value())

--- a/cache_impl_test.go
+++ b/cache_impl_test.go
@@ -1072,9 +1072,8 @@ func TestCache_CornerCases(t *testing.T) {
 		tc := newNonTickingClock()
 		loaderCallCount := 0
 		c := Must(&Options[int, int]{
-			Clock:             tc,
-			ExpiryCalculator:  ExpiryCreating[int, int](time.Hour),
-			RefreshCalculator: RefreshWriting[int, int](time.Hour),
+			Clock:            tc,
+			ExpiryCalculator: ExpiryCreating[int, int](time.Hour),
 		})
 
 		k1 := 1


### PR DESCRIPTION
## Description

**Problem**
When using `ExpiryCreating` calculator, expired items that get refreshed would lose their expiry time, causing the loader to be called on every subsequent `Get` request instead of respecting the original expiry duration.

**Root cause**
In `calcExpiresAtAfterWrite()`, when refreshing an expired item, the method would call `ExpireAfterUpdate()` instead of `ExpireAfterCreate()`. For `ExpiryCreating`, `ExpireAfterUpdate()` returns `entry.ExpiresAfter()`, which is 0 or negative for expired entries, resulting in no expiry time being set on the refreshed item.

**Solution**
Modified `calcExpiresAtAfterWrite()` to treat refresh operations as create operations when the old node has expired by checking `old.HasExpired(nowNano)`. This ensures refreshed expired items get proper expiry time calculated using `ExpireAfterCreate()`.

Code which was used to observe the described problem:

```
type key struct { id int }
type value struct { name string }

func TestBug(t *testing.T) {
    ctx := context.Background()

    cache, err := otter.New(&otter.Options[key, value]{
        ExpiryCalculator: otter.ExpiryCreating[key, value](5 * time.Second),
    })
    if err != nil {
        panic(err)
    }

    loader := otter.LoaderFunc[key, value](func(ctx context.Context, k key) (value, error) {
        fmt.Println("calling loader fn!")
        return value{name: "test"}, nil
    })

    // For the first 5 seconds, until the first expiration occurs, the loader is only once called.
    // Afterwards, it's being called on every Get call.
    ticker := time.NewTicker(100 * time.Millisecond)
    for range ticker.C {
        v, err := cache.Get(ctx, key{id: 1}, loader)
        if err != nil {
            panic(err)
        }
        fmt.Println("got value: ", v.name)
    }
}
```

## Related issue(s)

None

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
    - [x] If I added new functionality, I added tests covering it.
    - [x] If I fixed a bug, I added a regression test to prevent the bug from
      silently reappearing again.

- Documentation
    - [x] I checked whether I should update the docs and did so if necessary:
        - [README](../README.md)

- Public contracts
    - [x] My changes doesn't break project license.

#### Stylistic guide (mandatory)

- [x] My code complies with the [styles guide](https://github.com/uber-go/guide/blob/master/style.md).

#### Before merging (mandatory)
- [x] Check __target__  branch of PR is set correctly
