### PR TITLE
feat: add Entry.RecordHitMiss for conditional hit/miss tracking

### DIFF
--- a/cache_impl.go
+++ b/cache_impl.go
@@ -365,9 +365,12 @@ func (c *cache[K, V]) GetEntryQuietly(key K) (Entry[K, V], bool) {
 	nowNano := c.clock.NowNano()
 	n := c.getNodeQuietly(key, nowNano)
 	if n == nil {
-		return Entry[K, V]{}, false
+		return Entry[K, V]{c: c}, false
 	}
-	return c.nodeToEntry(n, nowNano), true
+	entry := c.nodeToEntry(n, nowNano)
+	entry.c = c
+	entry.n = n
+	return entry, true
 }
 
 // SetExpiresAfter specifies that the entry should be automatically removed from the cache once the duration has

--- a/entry.go
+++ b/entry.go
@@ -16,6 +16,8 @@ package otter
 
 import (
 	"time"
+
+	"github.com/maypok86/otter/v2/internal/generated/node"
 )
 
 // Entry is a key-value pair that may include policy metadata for the cached entry.
@@ -46,6 +48,55 @@ type Entry[K comparable, V any] struct {
 	//
 	// If the cache was not configured with a time-based policy then this value is always 0.
 	SnapshotAtNano int64
+
+	// c and n are set by GetEntryQuietly to allow deferred hit/miss
+	// recording via RecordHitMiss. They are nil for entries returned
+	// by other methods.
+	c *cache[K, V]
+	n node.Node[K, V] // nil when entry was not found
+}
+
+// RecordHitMiss retroactively records the outcome of a [Cache.GetEntryQuietly]
+// lookup as a cache hit (true) or miss (false).
+//
+// A hit updates statistics, the eviction policy, and expiration-on-read --
+// the same side effects as [Cache.GetEntry]. A miss updates only miss
+// statistics. The simplest correct usage is:
+//
+//	entry, ok := cache.GetEntryQuietly(key)
+//	entry.RecordHitMiss(ok)
+//	// equivalent to: entry, ok := cache.GetEntry(key)
+//
+// The value of separating lookup from recording is that the caller can
+// inspect the entry before deciding:
+//
+//	entry, ok := cache.GetEntryQuietly(key)
+//	if ok && isFresh(entry) {
+//	    entry.RecordHitMiss(true)
+//	    // use entry.Value
+//	} else {
+//	    entry.RecordHitMiss(false)
+//	    // fetch from backend
+//	}
+//
+// Calling RecordHitMiss(true) when the entry was not found (ok was false)
+// is a no-op: there is no cache entry whose policy state could be updated.
+// To record a miss in that case, pass false.
+//
+// If the entry is evicted between [Cache.GetEntryQuietly] and RecordHitMiss,
+// the policy update is best-effort, consistent with the inherent race window
+// in [Cache.GetEntry].
+//
+// On entries not returned by [Cache.GetEntryQuietly] this method is a no-op.
+func (e Entry[K, V]) RecordHitMiss(hit bool) {
+	if e.c == nil {
+		return
+	}
+	if hit && e.n != nil {
+		e.c.afterRead(e.n, e.c.clock.NowNano(), true, true)
+	} else if !hit {
+		e.c.stats.RecordMisses(1)
+	}
 }
 
 // ExpiresAt returns the entry's expiration time.

--- a/extension_test.go
+++ b/extension_test.go
@@ -388,3 +388,157 @@ func TestCache_Hottest(t *testing.T) {
 		require.ElementsMatch(t, slices.Collect(c.Keys()), keys)
 	})
 }
+
+func TestCache_RecordHitMiss(t *testing.T) {
+	t.Parallel()
+
+	newCache := func(t *testing.T) (*Cache[int, int], *stats.Counter) {
+		t.Helper()
+		counter := stats.NewCounter()
+		c := Must(&Options[int, int]{
+			MaximumSize:   100,
+			StatsRecorder: counter,
+		})
+		t.Cleanup(func() { c.StopAllGoroutines() })
+		c.Set(1, 100)
+		c.Set(2, 200)
+		c.CleanUp()
+		return c, counter
+	}
+
+	t.Run("hit updates stats", func(t *testing.T) {
+		t.Parallel()
+		c, counter := newCache(t)
+		baseline := counter.Snapshot()
+
+		entry, ok := c.GetEntryQuietly(1)
+		require.True(t, ok)
+		require.Equal(t, 100, entry.Value)
+
+		snap := counter.Snapshot()
+		require.Equal(t, baseline.Hits, snap.Hits, "GetEntryQuietly must not record hits")
+		require.Equal(t, baseline.Misses, snap.Misses, "GetEntryQuietly must not record misses")
+
+		entry.RecordHitMiss(true)
+		c.CleanUp()
+
+		snap = counter.Snapshot()
+		require.Equal(t, baseline.Hits+1, snap.Hits)
+		require.Equal(t, baseline.Misses, snap.Misses)
+	})
+
+	t.Run("miss on found entry updates stats", func(t *testing.T) {
+		t.Parallel()
+		c, counter := newCache(t)
+		baseline := counter.Snapshot()
+
+		entry, ok := c.GetEntryQuietly(1)
+		require.True(t, ok)
+
+		entry.RecordHitMiss(false)
+
+		snap := counter.Snapshot()
+		require.Equal(t, baseline.Hits, snap.Hits)
+		require.Equal(t, baseline.Misses+1, snap.Misses)
+	})
+
+	t.Run("miss on absent entry updates stats", func(t *testing.T) {
+		t.Parallel()
+		c, counter := newCache(t)
+		baseline := counter.Snapshot()
+
+		entry, ok := c.GetEntryQuietly(999)
+		require.False(t, ok)
+
+		entry.RecordHitMiss(false)
+
+		snap := counter.Snapshot()
+		require.Equal(t, baseline.Hits, snap.Hits)
+		require.Equal(t, baseline.Misses+1, snap.Misses)
+	})
+
+	t.Run("hit on absent entry is no-op", func(t *testing.T) {
+		t.Parallel()
+		c, counter := newCache(t)
+		baseline := counter.Snapshot()
+
+		entry, ok := c.GetEntryQuietly(999)
+		require.False(t, ok)
+
+		// Recording a hit on a not-found entry is a no-op
+		// (there is no node to update frequency for).
+		entry.RecordHitMiss(true)
+
+		snap := counter.Snapshot()
+		require.Equal(t, baseline.Hits, snap.Hits)
+		require.Equal(t, baseline.Misses, snap.Misses)
+	})
+
+	t.Run("GetEntry returns entry where RecordHitMiss is no-op", func(t *testing.T) {
+		t.Parallel()
+		c, counter := newCache(t)
+
+		entry, ok := c.GetEntry(1)
+		require.True(t, ok)
+
+		// GetEntry already recorded the hit.
+		snapBefore := counter.Snapshot()
+
+		// RecordHitMiss on a GetEntry entry should be a no-op.
+		entry.RecordHitMiss(true)
+		entry.RecordHitMiss(false)
+
+		snapAfter := counter.Snapshot()
+		require.Equal(t, snapBefore.Hits, snapAfter.Hits, "no additional hits after no-op RecordHitMiss")
+		require.Equal(t, snapBefore.Misses, snapAfter.Misses, "no additional misses after no-op RecordHitMiss")
+	})
+
+	t.Run("mixed sequence", func(t *testing.T) {
+		t.Parallel()
+		c, counter := newCache(t)
+		baseline := counter.Snapshot()
+
+		e1, ok := c.GetEntryQuietly(1)
+		require.True(t, ok)
+		e1.RecordHitMiss(true) // hit
+
+		e2, ok := c.GetEntryQuietly(2)
+		require.True(t, ok)
+		e2.RecordHitMiss(false) // miss
+
+		e3, ok := c.GetEntryQuietly(999)
+		require.False(t, ok)
+		e3.RecordHitMiss(false) // miss
+
+		c.CleanUp()
+
+		snap := counter.Snapshot()
+		require.Equal(t, baseline.Hits+1, snap.Hits)
+		require.Equal(t, baseline.Misses+2, snap.Misses)
+	})
+
+	t.Run("after StopAllGoroutines does not panic", func(t *testing.T) {
+		t.Parallel()
+		counter := stats.NewCounter()
+		c := Must(&Options[int, int]{
+			MaximumSize:   100,
+			StatsRecorder: counter,
+		})
+		c.Set(1, 100)
+		c.CleanUp()
+		baseline := counter.Snapshot()
+
+		entry, ok := c.GetEntryQuietly(1)
+		require.True(t, ok)
+
+		c.StopAllGoroutines()
+
+		// Must not panic.
+		entry.RecordHitMiss(true)
+		entry.RecordHitMiss(false)
+
+		snap := counter.Snapshot()
+		require.GreaterOrEqual(t, snap.Hits, baseline.Hits+1)
+		require.GreaterOrEqual(t, snap.Misses, baseline.Misses+1)
+	})
+}


### PR DESCRIPTION
## Summary

Adds `RecordHitMiss(hit bool)` method to `Entry`, enabling conditional hit/miss tracking as proposed in #178 (Peek/HitMiss approach).

- `GetEntryQuietly` (the "Peek") retrieves an entry without side effects
- `RecordHitMiss(true)` records a hit: updates both statistics and eviction policy (frequency/recency)
- `RecordHitMiss(false)` records a miss: updates only statistics
- For entries not from `GetEntryQuietly`, `RecordHitMiss` is a no-op

### Usage

```go
entry, ok := cache.GetEntryQuietly(key)
if ok && isFresh(entry) {
    entry.RecordHitMiss(true)
    // use entry.Value
} else {
    entry.RecordHitMiss(false)
    // fetch from backend
}
```

### Implementation

Stores `*cache[K,V]` and `node.Node[K,V]` directly in `Entry` (no closure allocation on the hot path). `GetEntryQuietly` sets these fields; all other `Entry`-returning methods leave them nil.

## Test plan

- [x] `GetEntryQuietly` + `RecordHitMiss(true)` increments hits
- [x] `GetEntryQuietly` + `RecordHitMiss(false)` increments misses (found and absent entries)
- [x] `GetEntryQuietly` alone does not update stats (regression check)
- [x] `GetEntry` returns entry where `RecordHitMiss` is a no-op
- [x] Mixed hit/miss sequence produces correct stats

Closes #178